### PR TITLE
Allow side-by-side usage with external Soda Theme

### DIFF
--- a/Soda Dark 3.sublime-theme
+++ b/Soda Dark 3.sublime-theme
@@ -7,7 +7,7 @@
     // Tab set
     {
         "class": "tabset_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-background.png",
         "layer0.inner_margin": [1, 7],
         "layer0.opacity": 1.0,
         "content_margin": [-4, 0, -4, 3],
@@ -33,7 +33,7 @@
         "content_margin": [12, 3, 12, 3],
         "max_margin_trim": 0,
         "hit_test_level": 0.0,
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-inactive.png",
         "layer0.inner_margin": [5, 5],
         "layer0.opacity": 1.0
     },
@@ -47,13 +47,13 @@
     {
         "class": "tab_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-hover.png"
     },
     // Tab active state
     {
         "class": "tab_control",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-active.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-active.png"
     },
     // Tab dirty state (close button hidden)
     {
@@ -86,7 +86,7 @@
         "settings": ["soda_classic_tabs"],
         "content_margin": [22, 6, 22, 4],
         "hit_test_level": 0.5,
-        "layer0.texture": "Theme - Soda/Soda Dark/classic/tab-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/classic/tab-inactive.png",
         "layer0.inner_margin": [18, 4]
     },
     // Tab close state
@@ -100,14 +100,14 @@
         "class": "tab_control",
         "settings": ["soda_classic_tabs"],
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/classic/tab-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/classic/tab-hover.png"
     },
     // Tab active state
     {
         "class": "tab_control",
         "settings": ["soda_classic_tabs"],
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/classic/tab-active.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/classic/tab-active.png"
     },
     // Tab dirty state (close button hidden)
     {
@@ -125,7 +125,7 @@
     {
         "class": "tab_close_button",
         "content_margin": [0, 0],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-close-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-close-inactive.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
@@ -137,20 +137,20 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-close.png",
         "layer0.opacity": 1.0
     },
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-close.png",
         "layer0.opacity": 1.0
     },
     // Tab dirty button
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-dirty-inactive.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-dirty-inactive.png"
     },
     {
         "class": "tab_close_button",
@@ -166,34 +166,34 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-dirty.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-dirty.png"
     },
     // Tab highlight button
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-highlight-inactive.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-highlight-inactive.png"
     },
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-highlight.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-highlight.png"
     },
     // Tab close button hover
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-close-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-close-hover.png"
     },
     // Tab close button pressed
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tab-close-pressed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tab-close-pressed.png"
     },
 
 //
@@ -234,40 +234,40 @@
     {
         "class": "show_tabs_dropdown_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-list.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-list.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "show_tabs_dropdown_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-list-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-list-hover.png"
     },
     // Tab scroll left
     {
         "class": "scroll_tabs_left_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-left.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-left.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "scroll_tabs_left_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-left-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-left-hover.png"
     },
     // Tab scroll right
     {
         "class": "scroll_tabs_right_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-right.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-right.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "scroll_tabs_right_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/tabset-right-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tabset-right-hover.png"
     },
 
 //
@@ -276,7 +276,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/fold-closed.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/fold-closed.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -284,17 +284,17 @@
     {
         "class": "fold_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/fold-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/fold-closed-hover.png"
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Dark/fold-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/fold-open.png"
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded", "hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/fold-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/fold-open-hover.png"
     },
 
 //
@@ -304,7 +304,7 @@
     // Standard vertical scroll bar
     {
         "class": "scroll_bar_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/standard-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/standard-scrollbar-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [2, 6],
         "blur": false
@@ -313,21 +313,21 @@
     {
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Dark/standard-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/standard-scrollbar-horizontal.png",
         "layer0.inner_margin": [6, 2],
         "blur": false
     },
     // Standard scroll bar corner
     {
         "class": "scroll_corner_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/standard-scrollbar-corner.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/standard-scrollbar-corner.png",
         "layer0.inner_margin": [2, 2],
         "layer0.opacity": 1.0
     },
     // Standard vertical scroll puck
     {
         "class": "puck_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/standard-puck-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/standard-puck-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [0, 10],
         "content_margin": [8, 12],
@@ -337,7 +337,7 @@
     {
         "class": "puck_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Dark/standard-puck-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/standard-puck-horizontal.png",
         "layer0.inner_margin": [10, 0],
         "content_margin": [12, 8],
         "blur": false
@@ -362,7 +362,7 @@
     {
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-scrollbar-vertical.png",
         "layer0.inner_margin": [0, 5],
         "blur": true
     },
@@ -371,7 +371,7 @@
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-scrollbar-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "blur": true
     },
@@ -379,7 +379,7 @@
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-puck-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-puck-vertical.png",
         "layer0.inner_margin": [0, 5],
         "content_margin": [5, 20],
         "blur": true
@@ -389,7 +389,7 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-puck-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-puck-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "content_margin": [20, 5],
         "blur": true
@@ -399,14 +399,14 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["dark"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-dark-puck-vertical.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-dark-puck-vertical.png"
     },
     // Overlay light horizontal puck (for dark content)
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal", "dark"],
-        "layer0.texture": "Theme - Soda/Soda Dark/overlay-dark-puck-horizontal.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/overlay-dark-puck-horizontal.png"
     },
 
 //
@@ -516,7 +516,7 @@
     // Tooltip container
     {
         "class": "tool_tip_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/tooltip.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/tooltip.png",
         "layer0.inner_margin": [1, 1],
         "layer0.opacity": 0.95,
         "content_margin": [3, 3]
@@ -534,7 +534,7 @@
     // Status bar container
     {
         "class": "status_bar",
-        "layer0.texture": "Theme - Soda/Soda Dark/status-bar-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/status-bar-background.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [2, 2],
         "content_margin": [8, 4, 8, 4]
@@ -560,7 +560,7 @@
     // Sidebar container
     {
         "class": "sidebar_container",
-        "layer0.texture": "Theme - Soda/Soda Dark/sidebar-bg.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/sidebar-bg.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [1, 1, 2, 1],
         "content_margin": [0, 0, 1, 0]
@@ -577,7 +577,7 @@
     // Sidebar rows
     {
         "class": "tree_row",
-        "layer0.texture": "Theme - Soda/Soda Dark/sidebar-row-selected.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/sidebar-row-selected.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": [1, 1]
     },
@@ -649,7 +649,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Soda/Soda Dark/file-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-close.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -663,31 +663,31 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Soda/Soda Dark/file-dirty.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-dirty.png",
         "layer0.opacity": 1.0
     },
     {
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/file-dirty-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-dirty-selected.png"
     },
     {
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/file-close.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-close.png"
     },
     // Sidebar file close hover
     {
         "class": "close_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/file-close-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-close-hover.png"
     },
     {
         "class": "close_button",
         "parents": [{"class": "tree_row", "attributes": ["hover", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/file-close-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/file-close-selected.png"
     },
 
 //
@@ -698,76 +698,76 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-closed.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-closed.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-closed-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-closed-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-closed-selected.png"
     },
     // Sidebar folder closed
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-closed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-closed-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed-selected.png"
     },
     // Sidebar group open
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-open.png"
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-open-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/group-open-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/group-open-selected.png"
     },
     // Sidebar folder open
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/folder-open-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open-selected.png"
     },
 
 //
@@ -779,7 +779,7 @@
         "class": "button_control",
         "content_margin": [6, 5, 6, 6],
         "min_size": [75, 0],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-large.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-large.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [6, 6]
     },
@@ -787,7 +787,7 @@
     {
         "class": "button_control",
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-large-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-large-on.png"
     },
 
 //
@@ -797,7 +797,7 @@
     // Text input field item
     {
         "class": "text_line_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/text-field.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/text-field.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [4, 5, 4, 3],
         "content_margin": [3, 4, 6, 3]
@@ -807,14 +807,14 @@
     {
         "class": "dropdown_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "Theme - Soda/Soda Dark/text-field-list.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/text-field-list.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [4, 4]
     },
     {
         "class": "dropdown_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/text-field-list-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/text-field-list-hover.png"
     },
 
 //
@@ -824,7 +824,7 @@
     // Bottom panel background
     {
         "class": "panel_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/panel-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/panel-background.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0,
         "content_margin": [2, 3, 2, 1]
@@ -833,10 +833,10 @@
     {
         "class": "overlay_control",
         "settings": ["!soda_retina_fix"],
-        "layer0.texture": "Theme - Soda/Soda Dark/quick-panel-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/quick-panel-background.png",
         "layer0.inner_margin": [12, 6, 12, 15],
         "layer0.opacity": 1.0,
-        "layer1.texture": "Theme - Soda/Soda Dark/quick-panel-sections.png",
+        "layer1.texture": "Theme - Sodarized/Soda Dark/quick-panel-sections.png",
         "layer1.inner_margin": [12, 40, 12, 19],
         "layer1.opacity": 1.0,
         "content_margin": [11, 8, 11, 17]
@@ -863,14 +863,14 @@
     },
     {
         "class": "quick_panel_row",
-        "layer0.texture": "Theme - Soda/Soda Dark/quick-panel-row.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/quick-panel-row.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0
     },
     {
         "class": "quick_panel_row",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/quick-panel-row-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/quick-panel-row-selected.png"
     },
     {
         "class": "quick_panel_label",
@@ -898,14 +898,14 @@
 
     {
         "class": "mini_quick_panel_row",
-        "layer0.texture": "Theme - Soda/Soda Dark/quick-panel-row.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/quick-panel-row.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0
     },
     {
         "class": "mini_quick_panel_row",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/quick-panel-row-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/quick-panel-row-selected.png"
     },
 
 //
@@ -931,7 +931,7 @@
     },
     {
         "class": "table_row",
-        "layer0.texture": "Theme - Soda/Soda Dark/autocomplete-row-selected.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/autocomplete-row-selected.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": [3, 1]
     },
@@ -948,7 +948,7 @@
     // Button group middle
     {
         "class": "icon_button_control",
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-middle.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-middle.png",
         "layer0.inner_margin": [6, 6],
         "layer0.opacity": 1.0,
         "content_margin": [3, 3]
@@ -956,61 +956,61 @@
     {
         "class": "icon_button_control",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-middle-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-middle-on.png"
     },
     // Button group left
     {
         "class": "icon_button_control",
         "attributes": ["left"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-left.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-left.png",
         "content_margin": [4, 3, 3, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["left", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-left-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-left-on.png"
     },
     // Button group right
     {
         "class": "icon_button_control",
         "attributes": ["right"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-right.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-right.png",
         "content_margin": [3, 3, 4, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["right", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-group-right-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-group-right-on.png"
     },
     // Button single
     {
         "class": "icon_button_control",
         "attributes": ["left", "right"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-small.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-small.png",
         "content_margin": [4, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["left", "right", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Dark/btn-small-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/btn-small-on.png"
     },
     // Panel close button
     {
         "class": "panel_close_button",
-        "layer0.texture": "Theme - Soda/Soda Dark/panel-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/panel-close.png",
         "layer0.opacity": 0.85,
         "content_margin": [8, 12]
     },
     {
         "class": "panel_close_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Dark/panel-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/panel-close.png",
         "layer0.opacity": 1.0
     },
     {
         "class": "panel_close_button",
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Dark/panel-close-pressed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/panel-close-pressed.png"
     },
 
 //
@@ -1020,38 +1020,38 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-regex-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-regex-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-regex-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-regex-on.png"
     },
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-case-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-case-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-case-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-case-on.png"
     },
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-word-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-word-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-word-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-word-on.png"
     },
 
 //
@@ -1061,26 +1061,26 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-context-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-context-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-context-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-context-on.png"
     },
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-buffer-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-buffer-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-buffer-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-buffer-on.png"
     },
 
 //
@@ -1090,38 +1090,38 @@
     // Reverse search direction button
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-reverse-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-reverse-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_reverse",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-reverse-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-reverse-on.png"
     },
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-wrap-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-wrap-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-wrap-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-wrap-on.png"
     },
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-selection-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-selection-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-selection-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-selection-on.png"
     },
 
 //
@@ -1131,14 +1131,14 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-preserve-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-preserve-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-preserve-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-preserve-on.png"
     },
 
 //
@@ -1148,14 +1148,14 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-highlight-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-highlight-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Dark/icon-highlight-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Dark/icon-highlight-on.png"
     }
 
 ]

--- a/Soda Dark/Widget - Soda Dark 3.sublime-settings
+++ b/Soda Dark/Widget - Soda Dark 3.sublime-settings
@@ -1,4 +1,4 @@
 {
-	"color_scheme": "Packages/Theme - Soda/Soda Dark/Widget - Soda Dark.stTheme",
+	"color_scheme": "Packages/Theme - Sodarized/Soda Dark/Widget - Soda Dark.stTheme",
 	"draw_shadows": false
 }

--- a/Soda Dark/Widget - Soda Dark.sublime-settings
+++ b/Soda Dark/Widget - Soda Dark.sublime-settings
@@ -1,4 +1,4 @@
 {
-	"color_scheme": "Packages/Theme - Soda/Soda Dark/Widget - Soda Dark.stTheme",
+	"color_scheme": "Packages/Theme - Sodarized/Soda Dark/Widget - Soda Dark.stTheme",
 	"draw_shadows": false
 }

--- a/Soda Light 3.sublime-theme
+++ b/Soda Light 3.sublime-theme
@@ -7,7 +7,7 @@
     // Tab set
     {
         "class": "tabset_control",
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-background.png",
         "layer0.inner_margin": [1, 7],
         "layer0.opacity": 1.0,
         "content_margin": [-4, 0, -4, 3],
@@ -33,7 +33,7 @@
         "content_margin": [12, 3, 12, 3],
         "max_margin_trim": 0,
         "hit_test_level": 0.0,
-        "layer0.texture": "Theme - Soda/Soda Light/tab-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-inactive.png",
         "layer0.inner_margin": [5, 5],
         "layer0.opacity": 1.0
     },
@@ -47,13 +47,13 @@
     {
         "class": "tab_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-hover.png"
     },
     // Tab active state
     {
         "class": "tab_control",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-active.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-active.png"
     },
     // Tab dirty state (close button hidden)
     {
@@ -86,7 +86,7 @@
         "settings": ["soda_classic_tabs"],
         "content_margin": [22, 6, 22, 4],
         "hit_test_level": 0.5,
-        "layer0.texture": "Theme - Soda/Soda Light/classic/tab-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/classic/tab-inactive.png",
         "layer0.inner_margin": [18, 4]
     },
     // Tab close state
@@ -100,14 +100,14 @@
         "class": "tab_control",
         "settings": ["soda_classic_tabs"],
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/classic/tab-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/classic/tab-hover.png"
     },
     // Tab active state
     {
         "class": "tab_control",
         "settings": ["soda_classic_tabs"],
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/classic/tab-active.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/classic/tab-active.png"
     },
     // Tab dirty state (close button hidden)
     {
@@ -125,7 +125,7 @@
     {
         "class": "tab_close_button",
         "content_margin": [0, 0],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-close-inactive.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-close-inactive.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
@@ -137,20 +137,20 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-close.png",
         "layer0.opacity": 0.85
     },
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-close.png",
         "layer0.opacity": 1.0
     },
     // Tab dirty button
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-dirty-inactive.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-dirty-inactive.png"
     },
     {
         "class": "tab_close_button",
@@ -166,34 +166,34 @@
     {
         "class": "tab_close_button",
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-dirty.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-dirty.png"
     },
     // Tab highlight button
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-highlight-inactive.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-highlight-inactive.png"
     },
     {
         "class": "tab_close_button",
         "settings": ["highlight_modified_tabs"],
         "parents": [{"class": "tab_control", "attributes": ["dirty", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-highlight.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-highlight.png"
     },
     // Tab close button hover
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-close-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-close-hover.png"
     },
     // Tab close button pressed
     {
         "class": "tab_close_button",
         "settings": ["show_tab_close_buttons"],
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Light/tab-close-pressed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tab-close-pressed.png"
     },
 
 //
@@ -234,40 +234,40 @@
     {
         "class": "show_tabs_dropdown_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-list.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-list.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "show_tabs_dropdown_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-list-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-list-hover.png"
     },
     // Tab scroll left
     {
         "class": "scroll_tabs_left_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-left.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-left.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "scroll_tabs_left_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-left-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-left-hover.png"
     },
     // Tab scroll right
     {
         "class": "scroll_tabs_right_button",
         "content_margin": [9, 7, 8, 6],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-right.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-right.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "scroll_tabs_right_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/tabset-right-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/tabset-right-hover.png"
     },
 
 //
@@ -276,7 +276,7 @@
 
     {
         "class": "fold_button_control",
-        "layer0.texture": "Theme - Soda/Soda Light/fold-closed.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/fold-closed.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -284,17 +284,17 @@
     {
         "class": "fold_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/fold-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/fold-closed-hover.png"
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Light/fold-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/fold-open.png"
     },
     {
         "class": "fold_button_control",
         "attributes": ["expanded", "hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/fold-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/fold-open-hover.png"
     },
 
 //
@@ -304,7 +304,7 @@
     // Standard vertical scroll bar
     {
         "class": "scroll_bar_control",
-        "layer0.texture": "Theme - Soda/Soda Light/standard-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/standard-scrollbar-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [2, 6],
         "blur": false
@@ -313,21 +313,21 @@
     {
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Light/standard-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/standard-scrollbar-horizontal.png",
         "layer0.inner_margin": [6, 2],
         "blur": false
     },
     // Standard scroll bar corner
     {
         "class": "scroll_corner_control",
-        "layer0.texture": "Theme - Soda/Soda Light/standard-scrollbar-corner.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/standard-scrollbar-corner.png",
         "layer0.inner_margin": [2, 2],
         "layer0.opacity": 1.0
     },
     // Standard vertical scroll puck
     {
         "class": "puck_control",
-        "layer0.texture": "Theme - Soda/Soda Light/standard-puck-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/standard-puck-vertical.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [0, 10],
         "content_margin": [8, 12],
@@ -337,7 +337,7 @@
     {
         "class": "puck_control",
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Light/standard-puck-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/standard-puck-horizontal.png",
         "layer0.inner_margin": [10, 0],
         "content_margin": [12, 8],
         "blur": false
@@ -362,7 +362,7 @@
     {
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-scrollbar-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-scrollbar-vertical.png",
         "layer0.inner_margin": [0, 5],
         "blur": true
     },
@@ -371,7 +371,7 @@
         "class": "scroll_bar_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-scrollbar-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-scrollbar-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "blur": true
     },
@@ -379,7 +379,7 @@
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-puck-vertical.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-puck-vertical.png",
         "layer0.inner_margin": [0, 5],
         "content_margin": [5, 20],
         "blur": true
@@ -389,7 +389,7 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-puck-horizontal.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-puck-horizontal.png",
         "layer0.inner_margin": [5, 0],
         "content_margin": [20, 5],
         "blur": true
@@ -399,14 +399,14 @@
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["dark"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-dark-puck-vertical.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-dark-puck-vertical.png"
     },
     // Overlay light horizontal puck (for dark content)
     {
         "class": "puck_control",
         "settings": ["overlay_scroll_bars"],
         "attributes": ["horizontal", "dark"],
-        "layer0.texture": "Theme - Soda/Soda Light/overlay-dark-puck-horizontal.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/overlay-dark-puck-horizontal.png"
     },
 
 //
@@ -516,7 +516,7 @@
     // Tooltip container
     {
         "class": "tool_tip_control",
-        "layer0.texture": "Theme - Soda/Soda Light/tooltip.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/tooltip.png",
         "layer0.inner_margin": [1, 1],
         "layer0.opacity": 0.95,
         "content_margin": [3, 3]
@@ -534,7 +534,7 @@
     // Status bar container
     {
         "class": "status_bar",
-        "layer0.texture": "Theme - Soda/Soda Light/status-bar-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/status-bar-background.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [2, 2],
         "content_margin": [8, 4, 8, 4]
@@ -560,7 +560,7 @@
     // Sidebar container
     {
         "class": "sidebar_container",
-        "layer0.texture": "Theme - Soda/Soda Light/sidebar-bg.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/sidebar-bg.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [1, 1, 2, 1],
         "content_margin": [0, 0, 1, 0]
@@ -576,7 +576,7 @@
     // Sidebar rows
     {
         "class": "tree_row",
-        "layer0.texture": "Theme - Soda/Soda Light/sidebar-row-selected.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/sidebar-row-selected.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": [1, 1]
     },
@@ -656,7 +656,7 @@
     // Sidebar file close
     {
         "class": "close_button",
-        "layer0.texture": "Theme - Soda/Soda Light/file-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-close.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": 0,
         "content_margin": [8, 8]
@@ -670,31 +670,31 @@
     {
         "class": "close_button",
         "attributes": ["dirty"],
-        "layer0.texture": "Theme - Soda/Soda Light/file-dirty.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-dirty.png",
         "layer0.opacity": 1.0
     },
     {
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/file-dirty-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-dirty-selected.png"
     },
     {
         "class": "close_button",
         "attributes": ["dirty"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/file-close.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-close.png"
     },
     // Sidebar file close hover
     {
         "class": "close_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/file-close-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-close-hover.png"
     },
     {
         "class": "close_button",
         "parents": [{"class": "tree_row", "attributes": ["hover", "selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/file-close-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/file-close-selected.png"
     },
 
 //
@@ -705,76 +705,76 @@
     {
         "class": "disclosure_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "Theme - Soda/Soda Light/group-closed.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-closed.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": 0
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/group-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-closed-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/group-closed-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-closed-selected.png"
     },
     // Sidebar folder closed
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-closed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-closed-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-closed-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed-selected.png"
     },
     // Sidebar group open
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Light/group-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-open.png"
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/group-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-open-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/group-open-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/group-open-selected.png"
     },
     // Sidebar folder open
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-open.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-open.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-open-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-open-hover.png"
     },
     {
         "class": "disclosure_button_control",
         "settings": ["soda_folder_icons"],
         "attributes": ["expanded"],
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/folder-open-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-open-selected.png"
     },
 
 //
@@ -786,7 +786,7 @@
         "class": "button_control",
         "content_margin": [6, 5, 6, 6],
         "min_size": [75, 0],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-large.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-large.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [6, 6]
     },
@@ -794,7 +794,7 @@
     {
         "class": "button_control",
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-large-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-large-on.png"
     },
 
 //
@@ -804,7 +804,7 @@
     // Text input field item
     {
         "class": "text_line_control",
-        "layer0.texture": "Theme - Soda/Soda Light/text-field.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/text-field.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [4, 5, 4, 3],
         "content_margin": [3, 4, 6, 3]
@@ -814,14 +814,14 @@
     {
         "class": "dropdown_button_control",
         "content_margin": [8, 8],
-        "layer0.texture": "Theme - Soda/Soda Light/text-field-list.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/text-field-list.png",
         "layer0.opacity": 1.0,
         "layer0.inner_margin": [4, 4]
     },
     {
         "class": "dropdown_button_control",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/text-field-list-hover.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/text-field-list-hover.png"
     },
 
 //
@@ -831,7 +831,7 @@
     // Bottom panel background
     {
         "class": "panel_control",
-        "layer0.texture": "Theme - Soda/Soda Light/panel-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/panel-background.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0,
         "content_margin": [2, 3, 2, 1]
@@ -840,10 +840,10 @@
     {
         "class": "overlay_control",
         "settings": ["!soda_retina_fix"],
-        "layer0.texture": "Theme - Soda/Soda Light/quick-panel-background.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/quick-panel-background.png",
         "layer0.inner_margin": [12, 6, 12, 15],
         "layer0.opacity": 1.0,
-        "layer1.texture": "Theme - Soda/Soda Light/quick-panel-sections.png",
+        "layer1.texture": "Theme - Sodarized/Soda Light/quick-panel-sections.png",
         "layer1.inner_margin": [12, 40, 12, 19],
         "layer1.opacity": 1.0,
         "content_margin": [11, 8, 11, 17]
@@ -869,14 +869,14 @@
     },
     {
         "class": "quick_panel_row",
-        "layer0.texture": "Theme - Soda/Soda Light/quick-panel-row.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/quick-panel-row.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0
     },
     {
         "class": "quick_panel_row",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/quick-panel-row-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/quick-panel-row-selected.png"
     },
     {
         "class": "quick_panel_label",
@@ -904,14 +904,14 @@
 
     {
         "class": "mini_quick_panel_row",
-        "layer0.texture": "Theme - Soda/Soda Light/quick-panel-row.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/quick-panel-row.png",
         "layer0.inner_margin": [2, 2, 2, 2],
         "layer0.opacity": 1.0
     },
     {
         "class": "mini_quick_panel_row",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/quick-panel-row-selected.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/quick-panel-row-selected.png"
     },
 
 //
@@ -937,7 +937,7 @@
     },
     {
         "class": "table_row",
-        "layer0.texture": "Theme - Soda/Soda Light/autocomplete-row-selected.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/autocomplete-row-selected.png",
         "layer0.opacity": 0.0,
         "layer0.inner_margin": [3, 1]
     },
@@ -954,7 +954,7 @@
     // Button group middle
     {
         "class": "icon_button_control",
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-middle.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-middle.png",
         "layer0.inner_margin": [6, 6],
         "layer0.opacity": 1.0,
         "content_margin": [3, 3]
@@ -962,61 +962,61 @@
     {
         "class": "icon_button_control",
         "attributes": ["selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-middle-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-middle-on.png"
     },
     // Button group left
     {
         "class": "icon_button_control",
         "attributes": ["left"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-left.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-left.png",
         "content_margin": [4, 3, 3, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["left", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-left-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-left-on.png"
     },
     // Button group right
     {
         "class": "icon_button_control",
         "attributes": ["right"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-right.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-right.png",
         "content_margin": [3, 3, 4, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["right", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-group-right-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-group-right-on.png"
     },
     // Button single
     {
         "class": "icon_button_control",
         "attributes": ["left", "right"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-small.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-small.png",
         "content_margin": [4, 3]
     },
     {
         "class": "icon_button_control",
         "attributes": ["left", "right", "selected"],
-        "layer0.texture": "Theme - Soda/Soda Light/btn-small-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/btn-small-on.png"
     },
     // Panel close button
     {
         "class": "panel_close_button",
-        "layer0.texture": "Theme - Soda/Soda Light/panel-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/panel-close.png",
         "layer0.opacity": 0.85,
         "content_margin": [8, 12]
     },
     {
         "class": "panel_close_button",
         "attributes": ["hover"],
-        "layer0.texture": "Theme - Soda/Soda Light/panel-close.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/panel-close.png",
         "layer0.opacity": 1.0
     },
     {
         "class": "panel_close_button",
         "attributes": ["pressed"],
-        "layer0.texture": "Theme - Soda/Soda Light/panel-close-pressed.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/panel-close-pressed.png"
     },
 
 //
@@ -1026,38 +1026,38 @@
     // Regex search button
     {
         "class": "icon_regex",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-regex-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-regex-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_regex",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-regex-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-regex-on.png"
     },
     // Case sensitive search button
     {
         "class": "icon_case",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-case-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-case-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-case-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-case-on.png"
     },
     // Match whole word search button
     {
         "class": "icon_whole_word",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-word-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-word-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_whole_word",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-word-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-word-on.png"
     },
 
 //
@@ -1067,26 +1067,26 @@
     // Show search context button
     {
         "class": "icon_context",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-context-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-context-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_context",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-context-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-context-on.png"
     },
     // Use search buffer
     {
         "class": "icon_use_buffer",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-buffer-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-buffer-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_use_buffer",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-buffer-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-buffer-on.png"
     },
 
 //
@@ -1096,38 +1096,38 @@
     // Reverse search direction button
     {
         "class": "icon_reverse",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-reverse-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-reverse-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_reverse",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-reverse-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-reverse-on.png"
     },
     // Search wrap button
     {
         "class": "icon_wrap",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-wrap-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-wrap-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_wrap",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-wrap-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-wrap-on.png"
     },
     // Search in selection button
     {
         "class": "icon_in_selection",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-selection-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-selection-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_in_selection",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-selection-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-selection-on.png"
     },
 
 //
@@ -1137,14 +1137,14 @@
     // Preserve case button
     {
         "class": "icon_preserve_case",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-preserve-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-preserve-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_preserve_case",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-preserve-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-preserve-on.png"
     },
 
 //
@@ -1154,14 +1154,14 @@
     // Highlight results button
     {
         "class": "icon_highlight",
-        "layer0.texture": "Theme - Soda/Soda Light/icon-highlight-off.png",
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-highlight-off.png",
         "layer0.opacity": 1.0,
         "content_margin": [9, 9]
     },
     {
         "class": "icon_highlight",
         "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
-        "layer0.texture": "Theme - Soda/Soda Light/icon-highlight-on.png"
+        "layer0.texture": "Theme - Sodarized/Soda Light/icon-highlight-on.png"
     }
 
 ]

--- a/Soda Light/Widget - Soda Light 3.sublime-settings
+++ b/Soda Light/Widget - Soda Light 3.sublime-settings
@@ -1,4 +1,4 @@
 {
-	"color_scheme": "Packages/Theme - Soda/Soda Light/Widget - Soda Light.stTheme",
+	"color_scheme": "Packages/Theme - Sodarized/Soda Light/Widget - Soda Light.stTheme",
 	"draw_shadows": false
 }

--- a/Soda Light/Widget - Soda Light.sublime-settings
+++ b/Soda Light/Widget - Soda Light.sublime-settings
@@ -1,4 +1,4 @@
 {
-	"color_scheme": "Packages/Theme - Soda/Soda Light/Widget - Soda Light.stTheme",
+	"color_scheme": "Packages/Theme - Sodarized/Soda Light/Widget - Soda Light.stTheme",
 	"draw_shadows": false
 }


### PR DESCRIPTION
As "Sodarized" recommends direct installation via git (git clone -b sodarized https://github.com/jrolfs/soda-theme.git "Theme - Sodarized") these changes allow a user to install it side-by-side with the regular Soda theme. I imagine that the texture folder names will change at some point in the future as well, but making it work for now was the goal.

Excellent work on the theme, by the way!
