### PR TITLE
Use folder icons for ST3

### DIFF
--- a/Sodarized Dark 3.sublime-theme
+++ b/Sodarized Dark 3.sublime-theme
@@ -714,19 +714,18 @@
     },
     // Sidebar folder closed
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed.png"
+        "class": "icon_folder",
+        "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed.png",
+        "layer0.opacity": 1.0,
+        "content_margin": [8, 8]
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
+        "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed-hover.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
+        "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.texture": "Theme - Sodarized/Soda Dark/folder-closed-selected.png"
     },
@@ -750,23 +749,18 @@
     },
     // Sidebar folder open
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
         "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
-        "parents": [{"class": "tree_row", "attributes": ["hover"]}],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded", "hover"]}],
         "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open-hover.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
-        "parents": [{"class": "tree_row", "attributes": ["selected"]}],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
         "layer0.texture": "Theme - Sodarized/Soda Dark/folder-open-selected.png"
     },
 

--- a/Sodarized Light 3.sublime-theme
+++ b/Sodarized Light 3.sublime-theme
@@ -721,19 +721,18 @@
     },
     // Sidebar folder closed
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed.png"
+        "class": "icon_folder",
+        "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed.png",
+        "layer0.opacity": 1.0,
+        "content_margin": [8, 8]
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
+        "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["hover"]}],
         "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed-hover.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
+        "class": "icon_folder",
         "parents": [{"class": "tree_row", "attributes": ["selected"]}],
         "layer0.texture": "Theme - Sodarized/Soda Light/folder-closed-selected.png"
     },
@@ -757,23 +756,18 @@
     },
     // Sidebar folder open
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded"]}],
         "layer0.texture": "Theme - Sodarized/Soda Light/folder-open.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
-        "parents": [{"class": "tree_row", "attributes": ["hover"]}],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded", "hover"]}],
         "layer0.texture": "Theme - Sodarized/Soda Light/folder-open-hover.png"
     },
     {
-        "class": "disclosure_button_control",
-        "settings": ["soda_folder_icons"],
-        "attributes": ["expanded"],
-        "parents": [{"class": "tree_row", "attributes": ["selected"]}],
+        "class": "icon_folder",
+        "parents": [{"class": "tree_row", "attributes": ["expanded", "selected"]}],
         "layer0.texture": "Theme - Sodarized/Soda Light/folder-open-selected.png"
     },
 


### PR DESCRIPTION
In ST3 folder icons aren't completely disabled, there is an ugly black outline of where a folder icon should be instead. This will fix it so ST3 uses the newer icons.
