### PR TITLE
Modified folder color (and hover) to more closely match sidebar scheme

### DIFF
--- a/Sodarized Light 3.sublime-theme
+++ b/Sodarized Light 3.sublime-theme
@@ -625,14 +625,14 @@
         "class": "sidebar_label",
         "parents": [{"class": "tree_row", "attributes": ["expandable"]}],
         "settings": ["bold_folder_labels"],
-        "color": [110, 126, 141],
+        "color": [90, 65, 50],
         "font.bold": true
     },
     {
         "class": "sidebar_label",
         "parents": [{"class": "tree_row", "attributes": ["expandable", "hover"]}],
         "settings": ["bold_folder_labels"],
-        "color": [81, 92, 103]
+        "color": [150, 100, 0]
     },
     // Sidebar entry selected
     {


### PR DESCRIPTION
Hey jrolfs - your sodarized plugin is awesome!

I did notice that in a recent update that the folder font color no longer really fits the Sodarized Light 3 sidebar theme (it's gray on top of champagne/tan), so I made some small color modifications to the theme file (folder font and hover color) so that it fits better. Here's a screenshot: http://imgur.com/gallery/cdBt1Ra

Also the blue fileselected.png file doesn't seem to fit the Sodarized Light theme very well -> what do you think of a brown/tan version of that? 
